### PR TITLE
update writer.go to support es8.x

### DIFF
--- a/stash/es/writer.go
+++ b/stash/es/writer.go
@@ -53,9 +53,9 @@ func (w *Writer) execute(vals []interface{}) {
 	for _, val := range vals {
 		pair := val.(valueWithIndex)
 		req := elastic.NewBulkIndexRequest().Index(pair.index)
-		if len(w.docType) > 0 {
-		    req = req.Type(w.docType)
-		}
+		// if len(w.docType) > 0 {
+		//     req = req.Type(w.docType)
+		// }
 		req = req.Doc(pair.val)
 		bulk.Add(req)
 	}


### PR DESCRIPTION
因为es8.x去掉了_type字段,因此在写es的时候 不能再设置type 值。